### PR TITLE
Fix evaluation.test.c

### DIFF
--- a/test/evaluation.test.c
+++ b/test/evaluation.test.c
@@ -14,7 +14,7 @@ TEST(cb_board_point_evaluation)
     cb_initialize_game(board);
 
     cb_board_evaluation expected_values;
-    expected_values.white_points += 8 * cb_piece_values[PAWN];
+    expected_values.white_points = 8 * cb_piece_values[PAWN];
     expected_values.white_points += 2 * cb_piece_values[ROOK];
     expected_values.white_points += 2 * cb_piece_values[KNIGHT];
     expected_values.white_points += 2 * cb_piece_values[BISHOP];


### PR DESCRIPTION
Fix edge case error on evaluation tests for platform Linux x86_64 when compiling with gcc